### PR TITLE
docs : git convention 링크 경로 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 ## :file_folder: Git Convention
 
-[자세히 보기](./blob/master/docs/git.md)
+[자세히 보기](./docs/git.md)
 
 ### Commit Message
 


### PR DESCRIPTION
상대 경로를 잘못 적었어요